### PR TITLE
Fix a display bug in the cpp demo.

### DIFF
--- a/examples/cpp/audio_main.cpp
+++ b/examples/cpp/audio_main.cpp
@@ -117,7 +117,7 @@ void handleTTSReplies(Diatheke::Session *session, std::string playCmd)
 void handleRecognizeEvent(const cobaltspeech::diatheke::RecognizeEvent &event)
 {
     // Color the text green if Diatheke recognized it, and red otherwise.
-    std::cout << event.valid_input() ? ANSIGreenText : ANSIRedText;
+    std::cout << (event.valid_input() ? ANSIGreenText : ANSIRedText);
 
     // Print out the text and reset the color
     std::cout << "Me: " << event.text() << ANSIResetText << std::endl;


### PR DESCRIPTION
This is a simple one-line PR.

Text coloring wasn't working quite right (order or operations bug).
Fixed by adding parenthesis around the offending code.