### PR TITLE
Fix typo in the python setup script.

### DIFF
--- a/grpc/py-diatheke/setup.py
+++ b/grpc/py-diatheke/setup.py
@@ -12,7 +12,7 @@ setup(
     url='https://github.com/cobaltspeech/sdk-diatheke',
     packages=["diatheke"],
     version_config={
-        "version_format": "{tag}.dev{commits}+{sha}"
+        "version_format": "{tag}.dev{sha}"
     },
     setup_requires=['better-setuptools-git-version'],
     install_requires=['grpcio-tools']


### PR DESCRIPTION
Removed the {commits} field from the version config. It doesn't
work with the better-setuptools-git-version pacakge.