### PR TITLE
Change python sdk dependencies.

### DIFF
--- a/grpc/py-diatheke/setup.py
+++ b/grpc/py-diatheke/setup.py
@@ -15,5 +15,5 @@ setup(
         "version_format": "{tag}.dev{sha}"
     },
     setup_requires=['better-setuptools-git-version'],
-    install_requires=['grpcio-tools']
+    install_requires=['protobuf', 'grpcio']
 )


### PR DESCRIPTION
Instead of using the grpcio-tools package, which includes the protoc compiler that clients will not need to use (we generate and commit the protoc-generated files to this repo), have the package depend on the protobuf and grpcio packages, which are the runtime components that the python sdk uses.