### PR TITLE
Java SDK and Docs

### DIFF
--- a/docs-src/content/audio-input/_index.md
+++ b/docs-src/content/audio-input/_index.md
@@ -64,7 +64,8 @@ self.asrStream = client.newSessionASRStream(token: token, asrResultHandler: { (r
 {{< /tab >}}
 
 {{< tab "Java/Android" "java" >}}
-// Example coming soon!
+// Example coming!
+// For now, please see https://grpc.io/docs/platforms/android/java/basics/#client-side-streaming-rpc
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/docs-src/content/audio-output/_index.md
+++ b/docs-src/content/audio-output/_index.md
@@ -43,7 +43,7 @@ self.ttsStream = self.client.newTTSStream(replyAction: replyAction, dataChunkHan
 {{< /tab >}}
 
 {{< tab "Java/Android" "java" >}}
-// Example coming soon!
+Iterator<TTSAudio> ttsResp = mDiathekeBlockingService.streamTTS(reply);
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -82,10 +82,6 @@ Diatheke::AudioWriter* audioOut;
 
 // Play the reply uninterrupted
 Diatheke::WriteTTSAudio(stream, audioOut);
-{{< /tab >}}
-
-{{< tab "Java/Android" "java" >}}
-// Example coming soon!
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -155,7 +151,18 @@ func handleReply(_ replyAction: Cobaltspeech_Diatheke_ReplyAction) {
 {{< /tab >}}
 
 {{< tab "Java/Android" "java" >}}
-// Example coming soon!
+private void requestAudio(ReplyAction reply) ByteArrayOutputStream {
+	// Make a request to the server for TTS audio
+	Iterator<TTSAudio> ttsResp = mDiathekeBlockingService.streamTTS(reply);
+
+	// Collect the audio into a single array
+	ByteArrayOutputStream os = new ByteArrayOutputStream();
+	while (ttsResp.hasNext()) {
+		os.write(ttsResp.next().getAudio().toByteArray());
+	}
+
+	return os;
+}
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/docs-src/content/error-handling/_index.md
+++ b/docs-src/content/error-handling/_index.md
@@ -86,24 +86,42 @@ client.createSession(modelID: model.id) { (sessionOutput) in
     print(error.localizedDescription)
 }
 ```
-## Android 
+## Android
 
-```java 
-diathekeStub.sessionEventStream(DiathekeOuterClass.SessionID.newBuilder().build(), new StreamObserver<DiathekeOuterClass.DiathekeEvent>() {
-            @Override
-            public void onNext(DiathekeOuterClass.DiathekeEvent value) {
-                // Handle success response here
-            }
+For synchronous calls, Java Exceptions are thrown by the generated gRPC calls, allowing the use of Try Catch blocks.
 
-            @Override
-            public void onError(Throwable t) {
-                // Handle the error here
-                Log.e("DIATHEKE_ERROR",t.getMessage());
-            }
+```java
+try {
+    SessionStart req = SessionStart.newBuilder().setModelId(modelId).build();
+    SessionOutput resp = mDiathekeBlockingService.createSession(req);
+} catch (StatusRuntimeException e) {
+    // Handle errors here
+}
+```
 
-            @Override
-            public void onCompleted() {
-                
-            }
-        });
+For asynchronous calls, the StreamObservers will include an onError callback method.
+
+```java
+// Create the callback observer
+StreamObserver<ASRResult> responseObserver = new StreamObserver<ASRResult>() {
+    @Override
+    public void onNext(ASRResult result) {
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        // Handle errors here
+    }
+
+    @Override
+    public void onCompleted() {
+    }
+};
+
+// Create stream
+StreamObserver<ASRInput> requestObserver = mDiathekeService.streamASR(responseObserver);
+
+// Send data
+requestObserver.onNext(cfg);
+requestObserver.onNext(audio);
 ```

--- a/docs-src/content/sessions/create.md
+++ b/docs-src/content/sessions/create.md
@@ -62,7 +62,14 @@ client.createSession(modelID: modelID) { (sessionOutput) in
 {{< /tab >}}
 
 {{< tab "Java/Android" "java" >}}
-// Example coming soon!
+// The specific model ID is defined by the Diatheke server.
+String modelID = "someID";
+SessionStart req = SessionStart.newBuilder().setModelId(modelId).build();
+
+SessionOutput resp = mDiathekeBlockingService.createSession(req);
+
+TokenData token = resp.getToken();
+List<ActionData> actionList = resp.getActionListList();
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/docs-src/content/sessions/delete.md
+++ b/docs-src/content/sessions/delete.md
@@ -45,7 +45,7 @@ client.deleteSession(token).response.whenComplete { (result) in
 {{< /tab >}}
 
 {{< tab "Java/Android" "java" >}}
-// Example coming soon!
+Empty e = mDiathekeBlockingService.deleteSession(mToken);
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/docs-src/content/sessions/update.md
+++ b/docs-src/content/sessions/update.md
@@ -44,7 +44,11 @@ client.processASRResult(token: token, asrResult: asrResult) { (sessionOutput) in
 {{< /tab >}}
 
 {{< tab "Java/Android" "java" >}}
-// Example coming soon!
+SessionInput input = SessionInput.newBuilder()
+		.setToken(mToken)
+		.setAsr(asrResult)
+		.build();
+SessionOutput resp = mDiathekeBlockingService.updateSession(input);
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -85,7 +89,15 @@ client.processText(token: token, text: text) { (sessionOutput) in
 {{< /tab >}}
 
 {{< tab "Java/Android" "java" >}}
-// Example coming soon!
+String text = "what's the weather forcast for today";
+TextInput txtMsg = TextInput.newBuilder()
+		.setText(text)
+		.build();
+SessionInput input = SessionInput.newBuilder()
+		.setToken(mToken)
+		.setText(txtMsg)
+		.build();
+SessionOutput resp = mDiathekeBlockingService.updateSession(input);
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -165,7 +177,24 @@ self.client.processCommandResult(token: token, commandResult: commandResult) { (
 {{< /tab >}}
 
 {{< tab "Java/Android" "java" >}}
-// Example coming soon!
+CommandResult.Builder commandResult = CommandResult.newBuilder();
+
+// Always use the original command ID in the result
+commandResult.setId(commandAction.getId());
+
+// If there are any output parameters expected by the model,
+// add them to the result.
+commandResult.putOutParameters("key", "val");
+
+// If there was a fatal error, set the error message in the result.
+commandResult.setError("I died");
+
+// Update the session with the result
+SessionInput input = SessionInput.newBuilder()
+		.setToken(mToken)
+		.setCmd(commandResult.build())
+		.build();
+SessionOutput resp = mDiathekeBlockingService.updateSession(input);
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -236,7 +265,19 @@ client.setStory(token: token, storyID: storyID, params: params) { (sessionOutput
 {{< /tab >}}
 
 {{< tab "Java/Android" "java" >}}
-// Example coming soon!
+String storyId = "alertStory"
+Map<String, String> h = new HashMap<String, String>();
+params.put("key","val");
+
+SetStory story = SetStory.newBuilder()
+		.setStoryId(storyId)
+		.putAllParameters(params)
+		.build();
+SessionInput input = SessionInput.newBuilder()
+		.setToken(mToken)
+		.setStory(story)
+		.build();
+SessionOutput resp = mDiathekeBlockingService.updateSession(input);
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/grpc/java-diatheke/README.md
+++ b/grpc/java-diatheke/README.md
@@ -73,6 +73,7 @@ This step should always pass without errors before publishing.
 
 To publish to GitHub Packages, simply run `./gradlew publish`.
 If you are building locally, you can use `./gradlew publishToMavenLocal` to publish to your `~/.m2/repositories/` at `com/cobaltspeech/diatheke/sdk-diatheke[-lite]`.
+This is helpful for debugging changes without the need of publishing to GitHub Packages.  Published versions can not be deleted.
 Please note:  Currently, the version is a variable set in the `lib/build.gradle`.  This should probably be refactored at some point.
 
 ### Cleaning

--- a/grpc/java-diatheke/lib/build.gradle
+++ b/grpc/java-diatheke/lib/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.cobaltspeech.diatheke'
-version = '2.0.0'
+version = '2.0.0-rc1'
 
 java {
     toolchain {

--- a/grpc/java-diatheke/liblite/build.gradle
+++ b/grpc/java-diatheke/liblite/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.cobaltspeech.diatheke'
-version = '2.0.0'
+version = '2.0.0-rc1'
 
 java {
     toolchain {


### PR DESCRIPTION
This commit has both the docs and the sdk.  I will separate those out into two separate commits before merging.  
I also want to add a link to our example application for a full java/android example, but we can do that in a future commit.
Please let me know if the tone in the documentation isn't consistent with the rest of stuff or if you want better formatting.  I haven't seen what it looks like rendered yet.

One other note: this doesn't have any client wrapping code.  That will be included in the example application, and once we finalize that, we can port it over here and update the code examples to use that client wrapper.  I was able to make all of the calls synchronous in that wrapper, except for the streaming ASR audio for a transcript.  I haven't figured out the cleanest way to push that into the client wrapper.  It was complicated by me being a little unfamiliar with Java and the fact that the stream can be canceled by either end, so error handling and managing the audio recorder state was still a little unclear.