### PR TITLE
docs: Fix broken relative links.

### DIFF
--- a/docs-src/content/_index.md
+++ b/docs-src/content/_index.md
@@ -15,14 +15,14 @@ with computers and mobile devices through audio and text based dialogs.
 
 ## Audio Based Dialogs
 Audio based dialog management uses multiple speech technologies, including
-[Automatic Speech Recognition (ASR)](glossary#asr),
-[Natural Language Understanding (NLU)](glossary#nlu), and
-[Text To Speech (TTS)](glossary#tts). It starts with audio input from a
+[Automatic Speech Recognition (ASR)](./glossary/#asr),
+[Natural Language Understanding (NLU)](./glossary/#nlu), and
+[Text To Speech (TTS)](./glossary/#tts). It starts with audio input from a
 calling application (human speech), which Diatheke sends to the ASR engine
 to get a transcription. This transcription is passed on to the NLU engine,
-which converts the transcription into an [intent](glossary#intent) and
-[entities](glossary#entity). The intent and entites are then used to
-perform an [action](glossary#action), as defined by the Diatheke model.
+which converts the transcription into an [intent](./glossary/#intent) and
+[entities](./glossary/#entity). The intent and entites are then used to
+perform an [action](./glossary/#action), as defined by the Diatheke model.
 One such action is for Diatheke to send a reply to the user. The reply text
 is sent to the TTS engine, which then synthesizes audio to send back to the
 client, as shown below.

--- a/docs-src/content/audio-input/_index.md
+++ b/docs-src/content/audio-input/_index.md
@@ -17,7 +17,7 @@ model is provided with the model information returned by the
 Use the session token to create the ASR stream.
 
 Developers who are creating their own bindings for the
-[gRPC interface](../protobuf) should note that the first message sent
+[gRPC interface](../protobuf/) should note that the first message sent
 on the stream returned by the `StreamASR` method should always be the
 session token.
 

--- a/docs-src/content/connecting/_index.md
+++ b/docs-src/content/connecting/_index.md
@@ -4,7 +4,7 @@ description: "Describes how to connect to a running Diatheke server instance."
 weight: 400
 ---
 
-Once you have the Diatheke server [up and running](../server),
+Once you have the Diatheke server [up and running](../server/),
 you are ready to create a client connection.
 
 <!--more-->

--- a/docs-src/content/sessions/_index.md
+++ b/docs-src/content/sessions/_index.md
@@ -21,7 +21,7 @@ expected paths a dialog may take, including what the user and the
 application are allowed to do during the dialog. A session is typically
 created when the calling application wants to start a new dialog from the beginning,
 with nothing saved in memory. At the time of session creation, Diatheke will also
-return a list of [actions](./actions) the application should take. While
+return a list of [actions](./actions/) the application should take. While
 processing these actions, the application will periodically need to update the
 session, at which point Diatheke will return additional actions the application
 should process. This cycle of processing actions and updating the session
@@ -37,10 +37,10 @@ session to respond to user's request to get the weather forecast.
 ### Voice I/O
 In this example, only voice interactions are defined between the user and
 the system (i.e., input is speech audio and output is synthesized speech
-audio). As shown below, the application starts by [creating a session](./create),
+audio). As shown below, the application starts by [creating a session](./create/),
 which returns a session token and a
 [WaitForUserAction](./actions/#wait-for-user-action). To get user input,
-the application then creates a new [ASR Stream](../audio-input) and starts
+the application then creates a new [ASR Stream](../audio-input/) and starts
 streaming audio data (e.g., from a microphone) to Diatheke.
 
 Eventually Diatheke will return an ASR result that includes a transcript
@@ -55,7 +55,7 @@ The relevant weather data is then used to update the session again via the
 [Process Command Result method](./update/#process-command-result), which
 in this example returns two actions the application should take. The first is a
 [ReplyAction](./actions/#reply-action), which should be used to create a
-new [TTS Stream](../audio-output). Audio from the TTS stream is played
+new [TTS Stream](../audio-output/). Audio from the TTS stream is played
 back to the user. Once playback is complete, the next action (another
 WaitForUserAction) is handled, and the process continues for the lifetime
 of the session.
@@ -64,7 +64,7 @@ of the session.
 
 ### Text I/O
 In this example, only text interactions are defined between the user and
-the system. As shown below, the application starts by [creating a session](./create),
+the system. As shown below, the application starts by [creating a session](./create/),
 which returns a session token and a
 [WaitForUserAction](./actions/#wait-for-user-action). In response to this
 action, the application uses an appropriate method to get input text from the

--- a/docs-src/content/sessions/actions.md
+++ b/docs-src/content/sessions/actions.md
@@ -13,12 +13,12 @@ to do next, and may be one of the following types:
 
 ## Processing the Action List
 There are currently two ways an application will receive an action list - when
-[creating a session](../create), and when [updating a session](../update).
+[creating a session](../create/), and when [updating a session](../update/).
 These action lists will always end with an action that requires a session
 update (such as a WaitForUserAction or a CommandAction), which will then
 return a new action list. This cycle of handling the session actions then
 updating the session repeats indefinitely, until the application decides it is
-time to [delete the session](../delete).
+time to [delete the session](../delete/).
 
 Here is an example showing how to process a typical action list:
 
@@ -242,7 +242,7 @@ public List<ActionData> waitForInput() throws StatusRuntimeException {
 
 
 Here is an example showing the application waiting for speech input from the user
-(see also [Audio Input](../../audio-input)).
+(see also [Audio Input](../../audio-input/)).
 
 {{< tabs >}}
 
@@ -455,7 +455,7 @@ wake word has been triggered, audio should again be sent to Diatheke.
 ## Reply Action
 The ReplyAction indicates that the calling application should give the information
 provided in the reply's text to the user. For applications using audio, see also
-[Audio Output](../../audio-output).
+[Audio Output](../../audio-output/).
 
 {{< tabs >}}
 

--- a/docs-src/content/sessions/create.md
+++ b/docs-src/content/sessions/create.md
@@ -8,7 +8,7 @@ To create a new session, the calling application must call the
 `CreateSession` method with the desired model ID as specified in the
 server configuration. To get a list of available models, see
 [here](../../connecting/#models). A new session token will be returned
-along with a list of [actions](../actions).
+along with a list of [actions](../actions/).
 
 {{< tabs >}}
 

--- a/docs-src/content/sessions/update.md
+++ b/docs-src/content/sessions/update.md
@@ -4,16 +4,16 @@ description: "How to update the state of a session using one of the allowed inpu
 weight: 530
 ---
 
-In the underlying [gRPC API](../../protobuf), the `UpdateSession` method
+In the underlying [gRPC API](../../protobuf/), the `UpdateSession` method
 is called using one of several data types to update the session. For the
 sake of convenience, the SDK provides several functions to handle each
 type of session update. Updating the session always requires the current
-session token and will return an updated token with a new [action list](../actions).
+session token and will return an updated token with a new [action list](../actions/).
 
 ## Process ASR Result
-When an [ASR stream](../../audio-input) returns a result, it may be used
+When an [ASR stream](../../audio-input/) returns a result, it may be used
 directly to update the session. This is usually called in response to a
-[Wait For User Action](../actions/#wait-for-user-action). It is the audio
+[Wait For User Action](../actions/#wait-for-user-action/). It is the audio
 equivalent of [Process Text](#process-text).
 
 {{< tabs >}}
@@ -201,7 +201,7 @@ SessionOutput resp = mDiathekeBlockingService.updateSession(input);
 
 ## Set Story
 The `SetStory` method of the API may be used to update a session to begin
-running from a specified [story](../../glossary#story) in the model. This method is particularly
+running from a specified [story](../../glossary/#story) in the model. This method is particularly
 useful for implementing system initiated alerts, or to update a session in
 a mixed UI environment (GUI + voice).
 


### PR DESCRIPTION
Following these links would lead to a state where relative links
stop working. Adding trailing slashes to the page fixes it.