### PR TITLE
fix(cmake): Always build gRPC as a static library in C++.

### DIFF
--- a/grpc/cpp-diatheke/CobaltGRPC.cmake
+++ b/grpc/cpp-diatheke/CobaltGRPC.cmake
@@ -17,6 +17,12 @@ if(USE_SYSTEM_GRPC)
     add_executable(protoc ALIAS protobuf::protoc)
     add_executable(grpc_cpp_plugin ALIAS grpc::grpc_cpp_plugin)
 else()
+    # Make sure we build gRPC as a static library, regardless of
+    # whether Diatheke is built as a shared library.
+    cmake_policy(SET CMP0077 NEW)
+    set(OLD_BUILD_SHARED ${BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS FALSE)
+
     # Download gRPC from github and add it as part of the project
     include(FetchContent)
     FetchContent_Declare(
@@ -38,6 +44,9 @@ else()
 
     # Add gRPC to the project
     FetchContent_MakeAvailable(gRPC)
+
+    # Restore the BUILD_SHARED_LIBS flag
+    set(BUILD_SHARED_LIBS ${OLD_BUILD_SHARED})
 endif()
 
 # This allows cross-compiling to work - a native version of protoc is required.


### PR DESCRIPTION
Updated CMake to always build gRPC as a static library, regardless
of whether or not the Diatheke SDK is built as a shared library.
When building a shared library, this results in the gRPC library
being included as part of the libdiatheke_client.so shared library,
instead of also having the many separate *.so libs for gRPC. From
a practical standpoint, it is then much easier to manage the one
libdiatheke_client.so library and link against it in other projects.