### PR TITLE
docs: Add documentation for the new Transcribe method.

### DIFF
--- a/docs-src/content/audio-input/_index.md
+++ b/docs-src/content/audio-input/_index.md
@@ -6,15 +6,32 @@ weight: 600
 
 To process a user's speech, the calling application may create an 
 [ASR](../glossary/#asr) stream. Bytes of audio data are sent to the
-stream until the stream is closed and an ASR result, which includes
-a transcript of the speech, is returned. The audio data encoding must
+stream and the server returns ASR results, which include a transcript
+of the speech, until the stream is closed. The audio data encoding must
 match what is expected by the server. The sample rate for any given
 model is provided with the model information returned by the
-[ListModels](../connecting/#list-models) method.
+[ListModels](../connecting/#list-models) method. Currently, Diatheke
+supports two different ASR streams:
 
+* [StreamASR](#streamasr) - used to handle a conversation turn with Diatheke.
+* [Transcribe](#transcribe) - used to get an application specific 
+  transcript not intended to control the dialog.
 
-## Creating the ASR Stream
-Use the session token to create the ASR stream.
+For simplified usage, take a look at the [convenience functions](#convenience-functions).
+
+## StreamASR
+This method is used to handle a single conversation turn with Diatheke, where
+the user is expected to provide input before Diatheke continues to the next
+action. It includes functionality for [wake word](#wake-word) detection
+and speech processing in the context of the current dialog state.
+Unlike the Transcribe stream, this stream will only ever return a single
+ASR result, which may be used to
+[update a session](../sessions/update/#process-asr-result), at which point
+the stream is closed and a new stream is created for the next [Wait For User
+action](../sessions/actions/#wait-for-user-action).
+
+### Creating the ASR Stream
+Use the [session token](../sessions/create) to create the ASR stream.
 
 Developers who are creating their own bindings for the
 [gRPC interface](../protobuf/) should note that the first message sent
@@ -71,61 +88,7 @@ self.asrStream = client.newSessionASRStream(token: token, asrResultHandler: { (r
 {{< /tabs >}}
 
 
-## Convenience Functions
-The SDK includes some convenience functions to make it easier to send
-audio data to Diatheke and get a result. These typically use a reader
-type with the ASR stream created earlier. Applications are more than welcome
-to instead use the stream methods directly to [send audio](#sending-audio)
-and [get a result](#asr-result) if these convenience functions do not
-meet their needs.
-
-{{< tabs >}}
-
-{{< tab "Go" "go" >}}
-// Set up the audio source as an io.Reader
-var audioSource io.Reader
-
-// send 8kB chunks at a time
-buffSize := 8192
-
-// Process audio until we get a result or the audioSource returns
-// io.EOF, whichever comes first.
-result, err := diatheke.ReadASRAudio(stream, audioSource, buffSize)
-fmt.Printf("transcript: %v\n", result.Text)
-{{< /tab >}}
-
-{{< tab "Python" "python">}}
-# The audio source should implement a read(size) function, such as
-# a file object or process pipe.
-audioSource = getAudioSource()
-
-# send 8kB chunks at a time
-buffSize = 8192
-
-# Process audio until we get a result or the reader returns empty
-# bytes (EOF), whichever comes first.
-result = diatheke.read_ASR_audio(stream, audioSource, buffSize)
-print("transcript:", result.text)
-{{< /tab >}}
-
-{{< tab "C++" "c++" >}}
-// The audio source should inherit from the Diatheke::AudioReader class.
-Diatheke::AudioReader* audioSource;
-
-// Send 8kB chunks at a time
-size_t buffSize = 8192;
-
-// Process audio until we get a result or the number of bytes read
-// (as returned by the Diatheke::AudioReader) is zero.
-cobaltspeech::diatheke::ASRResult result =
-    Diatheke::ReadASRAudio(stream, audioSource, buffSize);
-std::cout << "transcript: " << result.text() << std::endl;
-{{< /tab >}}
-
-{{< /tabs >}}
-
-
-## Sending Audio
+### Sending Audio
 After the stream is created, audio data is sent repeatedly over the
 stream until the stream is closed or there is no more audio to send.
 
@@ -178,7 +141,7 @@ asrStream.sendAudio(data: data, completion: { (error) in
 {{< /tabs >}}
 
 
-## ASR Result
+### ASR Result
 When there is no more audio data to send, or if the ASR stream was
 closed by the server, the application may retrieve the ASR result, which
 includes a transcript of what was spoken. This result may be used to
@@ -256,6 +219,319 @@ self.asrStream.result(completion: { (error) in
 		print(error.localizedDescription)
 	}
 })
+{{< /tab >}}
+
+{{< /tabs >}}
+
+## Transcribe
+This method is used to get a general purpose transcription from Diatheke.
+Unlike the StreamASR method, the transcripts returned on this stream are
+not used to update the session. Their purpose is application specific,
+and the application can use the transcripts for anything. This stream
+does not use [wake word](#wake-word) detection to begin the transcription,
+but it may have conditions defined in the Diatheke model to end the
+transcription, such as a non-speech timeout (i.e, speech not detected for
+a specified duration), or a sleep word (i.e, a word or phrase to indicate
+that the transcription should end). A single Transcribe stream may return
+multiple [results](#transcribe-results) before it is finished.
+
+### Creating the Transcribe Stream
+Use the [Transcribe action](../sessions/actions/#transcribe-action)
+to create the Transcribe stream.
+
+Developers who are creating their own bindings for the
+[gRPC interface](../protobuf/) should note that the first message sent
+on the stream returned by the `Transcribe` method should always be the
+transcribe action.
+
+{{< tabs >}}
+
+{{< tab "Go" "go" >}}
+// Create the transcribe stream. This automatically sends the transcribe
+// action on the stream first.
+stream, err := client.NewTranscribeStream(context.Background(), action)
+{{< /tab >}}
+
+{{< tab "Python" "python">}}
+# Create the transcribe stream. This automatically sends the transcribe
+# action on the stream first.
+stream = client.new_transcribe_stream(action)
+{{< /tab >}}
+
+{{< tab "C++" "c++" >}}
+// Create the transcribe stream. This automatically sends the transcribe
+// action on the stream first.
+Diatheke::TranscribeStream stream = client.newTranscribeStream(action);
+{{< /tab >}}
+
+{{< /tabs >}}
+
+### Sending Audio
+After the stream is created, audio data is sent repeatedly over the
+stream until the stream is closed or there is no more audio to send.
+Because the Transcribe stream is bidirectional, this must be done
+concurrently with receiving results. For most programming languages,
+this means it should be handled on a separate thread.
+
+{{< tabs >}}
+
+{{< tab "Go" "go" >}}
+var audioData []byte
+for haveAudioData {
+	audioData = getFromSource()
+
+	// Send the audio bytes
+	if err := stream.SendAudio(audioData); err == io.EOF {
+		// The stream has been closed, and a result is available.
+		break
+	}
+}
+
+// Be sure to close the stream to notify the server that no more
+// audio will be coming.
+err = stream.SendFinished()
+{{< /tab >}}
+
+{{< tab "Python" "python">}}
+while haveAudioData:
+    audioData = getFromSource()
+
+    # Send the audio bytes
+    if not stream.send_audio(audioData):
+        # The stream has been closed
+        break
+
+# Be sure to close the stream to notify the server that no more
+# audio will be coming.
+stream.send_finished()
+{{< /tab >}}
+
+{{< tab "C++" "c++" >}}
+while (haveAudioData) {
+    std::string audioData = getFromSource();
+
+    // Send the audio bytes
+    if (!stream.sendAudio(audioData)) {
+        // The stream has been closed
+        break;
+    }
+}
+
+// Be sure to close the stream to notify the server that no more
+// audio will be coming.
+stream.sendFinished();
+{{< /tab >}}
+
+{{< /tabs >}}
+
+### Transcribe Results
+Multiple results may be sent on the receiving half of the Transcribe
+stream during its lifetime. Some of these results are partial, which
+indicate that the result may change with further processing. Partial
+results are mainly useful for displaying progress to a user in a
+graphical user interface if one is being used. Non-partial results
+contain the final transcript that is of interest to the application.
+Note that multiple non-partial results may be accumlated by the
+application before the stream ends.
+
+Due to the bidirection nature of the Transcribe stream, results must
+be processed concurrently with sending audio data. This may be done
+on any thread, and it is often done on the main thread, as many
+applications don't wish to continue processing until the transcription
+is complete. However, it is not a strict requirement that results be
+processed on the main thread, and an application should adopt an
+architecture that makes the most sense for its use case.
+
+{{< tabs >}}
+
+{{< tab "Go" "go" >}}
+// Process results as they come.
+for {
+	result, err := stream.ReceiveResult()
+	if err == io.EOF {
+		// The stream has closed
+		return
+	} else if err != nil {
+		// Handle the error
+		return
+	}
+
+	// The transcript
+	fmt.Printf("text: %v\n", result.Text)
+
+	// The confidence the ASR system has in the given transcript,
+	// given as a value between 0 and 1.0, with 1.0 being the most
+	// confident in the result. Note that partial results won't
+	// have an accurate confidence score.
+	fmt.Printf("confidence: %v\n", result.Confidence)
+
+	// Boolean indicating whether the result is partial (i.e., may
+	// change with further processing).
+	fmt.Printf("partial: %v\n\n", result.IsPartial)
+}
+{{< /tab >}}
+
+{{< tab "Python" "python">}}
+# Process results as they come.
+while True:
+    result = stream.receive_result()
+    if result is None:
+        # The stream has closed
+        break
+
+    # The transcript
+    print("text:", result.text)
+
+    # The confidence the ASR system has in the given transcript,
+    # given as a value between 0 and 1.0, with 1.0 being the most
+    # confident in the result. Note that partial results won't
+    # have an accurate confidence score.
+    print("confidence:", result.confidence)
+
+    # Boolean indicating whether the result is partial (i.e., may
+    # change with further processing).
+    print("partial:", result.is_partial)
+{{< /tab >}}
+
+{{< tab "C++" "c++" >}}
+while (true) {
+    cobaltspeech::diatheke::TranscribeResult result;
+    if (!stream.receiveResult(&result)) {
+        // The stream has closed
+        break;
+    }
+
+    // The transcript
+    std::cout << "text: " << result.text() << std::endl;
+
+    // The confidence the ASR system has in the given transcript,
+    // given as a value between 0 and 1.0, with 1.0 being the most
+    // confident in the result. Note that partial results won't
+    // have an accurate confidence score.
+    std::cout << "confidence: " << result.confidence() << std::endl;
+
+    // Boolean indicating whether the result is partial (i.e., may
+    // change with further processing).
+    std::cout << "partial: " << result.is_partial() << std::endl;
+}
+{{< /tab >}}
+
+{{< /tabs >}}
+
+
+## Convenience Functions
+The SDK includes some convenience functions to make it easier to send
+audio data to Diatheke and get results. These typically use a reader
+type with the ASR stream created earlier. Applications are more than welcome
+to instead use the stream methods directly to [send audio](#sending-audio)
+and [get a result](#asr-result) if these convenience functions do not
+meet their needs.
+
+### ReadASRAudio
+{{< tabs >}}
+
+{{< tab "Go" "go" >}}
+// Set up the audio source as an io.Reader
+var audioSource io.Reader
+
+// Send up to 8kB chunks of audio at a time
+buffSize := 8192
+
+// Process audio until we get a result or the audioSource returns
+// io.EOF, whichever comes first.
+result, err := diatheke.ReadASRAudio(stream, audioSource, buffSize)
+fmt.Printf("transcript: %v\n", result.Text)
+{{< /tab >}}
+
+{{< tab "Python" "python">}}
+# The audio source should implement a read(size) function, such as
+# a file object or process pipe.
+audioSource = getAudioSource()
+
+# Send up to 8kB chunks of audio at a time
+buffSize = 8192
+
+# Process audio until we get a result or the reader returns empty
+# bytes (EOF), whichever comes first. Note that for Python, this
+# convenience function does not take a stream, but instead uses
+# the client object directly.
+result = client.read_asr_audio(session.token, audioSource, buffSize)
+print("transcript:", result.text)
+{{< /tab >}}
+
+{{< tab "C++" "c++" >}}
+// The audio source should inherit from the Diatheke::AudioReader class.
+Diatheke::AudioReader* audioSource;
+
+// Send up to 8kB chunks of audio at a time
+size_t buffSize = 8192;
+
+// Process audio until we get a result or the number of bytes read
+// (as returned by the Diatheke::AudioReader) is zero.
+cobaltspeech::diatheke::ASRResult result =
+    Diatheke::ReadASRAudio(stream, audioSource, buffSize);
+std::cout << "transcript: " << result.text() << std::endl;
+{{< /tab >}}
+
+{{< /tabs >}}
+
+### ReadTranscribeAudio
+{{< tabs >}}
+
+{{< tab "Go" "go" >}}
+// Set up the audio source as an io.Reader
+var audioSource io.Reader
+
+// Send up to 8kB chunks of audio at a time
+buffSize := 8192
+
+// Set up a result callback
+handler := func(result *diathekepb.TranscribeResult) {
+	// Do something interesting with the result
+	fmt.Printf("result: %+v\n", result)
+}
+
+// Call the convenience function, which will block until the audio source
+// returns io.EOF or the stream closes.
+err := diatheke.ReadTranscribeAudio(stream, audioSource, buffSize, handler)
+{{< /tab >}}
+
+{{< tab "Python" "python">}}
+# The audio source should implement a read(size) function, such as
+# a file object or process pipe.
+audioSource = getAudioSource()
+
+# Send up to 8kB chunks of audio at a time
+buffSize = 8192
+
+# Set up a result callback
+def handler(result):
+    # Do something interesting with the result
+    print("result text:", result.text)
+
+# Call the convenience function, which will block until the audio
+# source returns EOF or the stream closes. Note that for Python, this
+# convenience function does not take a stream, but instead uses
+# the client object directly.
+client.read_transcribe_audio(action, audioSource, buffSize, handler)
+{{< /tab >}}
+
+{{< tab "C++" "c++" >}}
+// The audio source should inherit from the Diatheke::AudioReader class.
+Diatheke::AudioReader* audioSource;
+
+// Send up to 8kB chunks of audio at a time
+size_t buffSize = 8192;
+
+// Set up a result callback
+auto handler = [](const cobaltspeech::diatheke::TranscribeResult &result) {
+    // Do something interesting with the result.
+    std::cout << "result text: " << result.text() << std::endl;
+}
+
+// Call the convenience function, which will block until the audio
+// source returns EOF or the stream closes.
+Diatheke::ReadTranscribeAudio(stream, audioSource, buffSize, handler);
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/docs-src/content/audio-input/_index.md
+++ b/docs-src/content/audio-input/_index.md
@@ -264,6 +264,33 @@ stream = client.new_transcribe_stream(action)
 Diatheke::TranscribeStream stream = client.newTranscribeStream(action);
 {{< /tab >}}
 
+{{< tab "Swift/iOS" "swift" >}}
+// Create the transcribe stream. This automatically sends the transcribe
+// action on the stream first.
+let stream = self.newTranscribeStream(action: action) { result in
+	// Boolean indicating whether the result is partial (i.e., may
+	// change with further processing).
+	if result.isPartial {
+		// Print the partial transcript.
+		print("Partial transcript: \(result.text)")
+	} else {
+		// Print the finalized transcript.
+		print("Transcript: \(result.text)")
+
+		// The confidence the ASR system has in the given transcript,
+		// given as a value between 0 and 1.0, with 1.0 being the most
+		// confident in the result. Note that partial results won't
+		// have an accurate confidence score.
+		print("Confidence: \(result.confidence)")
+	}
+} completion: { error in
+	if let error = error {
+		// Handle the error
+		print(error.localizedDescription)
+	}
+}
+{{< /tab >}}
+
 {{< /tabs >}}
 
 ### Sending Audio
@@ -320,6 +347,24 @@ while (haveAudioData) {
 // Be sure to close the stream to notify the server that no more
 // audio will be coming.
 stream.sendFinished();
+{{< /tab >}}
+
+{{< tab "Swift/iOS" "swift" >}}
+while let audioData = getDataFromSource(), !audioData.isEmpty {
+	stream.sendAudio(audioData) { error in
+		if let error = error {
+			print(error.localizedDescription)
+		}
+	}
+}
+
+// Be sure to close the stream to notify the server that no more
+// audio will be coming.
+stream.finish { error in
+	if let error = error {
+		print(error.localizedDescription)
+	}
+}
 {{< /tab >}}
 
 {{< /tabs >}}
@@ -422,6 +467,41 @@ while (true) {
         std::cout << "confidence: " << result.confidence() << std::endl;
     }
 }
+{{< /tab >}}
+
+{{< tab "Swift/iOS" "swift" >}}
+// Transcribe Results come to transcribeResultHandler block on creating TranscribeStream
+let transcribeStream = self.newTranscribeStream(action: action) { result in
+	// Boolean indicating whether the result is partial (i.e., may
+	// change with further processing).
+	if result.isPartial {
+		// Print the partial transcript.
+		print("Partial transcript: \(result.text)")
+	} else {
+		// Print the finalized transcript.
+		print("Transcript: \(result.text)")
+
+		// The confidence the ASR system has in the given transcript,
+		// given as a value between 0 and 1.0, with 1.0 being the most
+		// confident in the result. Note that partial results won't
+		// have an accurate confidence score.
+		print("Confidence: \(result.confidence)")
+	}
+} completion: { error in
+	if let error = error {
+		// Handle the error
+		print(error.localizedDescription)
+	}
+}
+
+// When there is no more audio data to send
+// (i.e. when the app needs to stop recording audio)
+// call TranscribeStream's finish() method to close the Transcribe stream
+transcribeStream.finish { error in
+	if let error = error {
+		print(error.localizedDescription)
+	}
+})
 {{< /tab >}}
 
 {{< /tabs >}}

--- a/docs-src/content/audio-input/_index.md
+++ b/docs-src/content/audio-input/_index.md
@@ -227,7 +227,7 @@ self.asrStream.result(completion: { (error) in
 This method is used to get a general purpose transcription from Diatheke.
 Unlike the StreamASR method, the transcripts returned on this stream are
 not used to update the session. Their purpose is application specific,
-and the application can use the transcripts for anything. This stream
+such as taking a note, sending a text message, etc. This stream
 does not use [wake word](#wake-word) detection to begin the transcription,
 but it may have conditions defined in the Diatheke model to end the
 transcription, such as a non-speech timeout (i.e, speech not detected for
@@ -331,10 +331,10 @@ indicate that the result may change with further processing. Partial
 results are mainly useful for displaying progress to a user in a
 graphical user interface if one is being used. Non-partial results
 contain the final transcript that is of interest to the application.
-Note that multiple non-partial results may be accumlated by the
+Note that multiple non-partial results may be received by the
 application before the stream ends.
 
-Due to the bidirection nature of the Transcribe stream, results must
+Due to the bidirectional nature of the Transcribe stream, results must
 be processed concurrently with sending audio data. This may be done
 on any thread, and it is often done on the main thread, as many
 applications don't wish to continue processing until the transcription
@@ -356,18 +356,21 @@ for {
 		return
 	}
 
-	// The transcript
-	fmt.Printf("text: %v\n", result.Text)
-
-	// The confidence the ASR system has in the given transcript,
-	// given as a value between 0 and 1.0, with 1.0 being the most
-	// confident in the result. Note that partial results won't
-	// have an accurate confidence score.
-	fmt.Printf("confidence: %v\n", result.Confidence)
-
 	// Boolean indicating whether the result is partial (i.e., may
 	// change with further processing).
-	fmt.Printf("partial: %v\n\n", result.IsPartial)
+	if result.IsPartial {
+		// Print the partial transcript.
+		fmt.Printf("partial transcript: %v\n", result.Text)
+	} else {
+		// Print the finalized transcript.
+		fmt.Printf("transcript: %v\n", result.Text)
+		
+		// The confidence the ASR system has in the given transcript,
+		// given as a value between 0 and 1.0, with 1.0 being the most
+		// confident in the result. Note that partial results won't
+		// have an accurate confidence score.
+		fmt.Printf("confidence: %v\n", result.Confidence)
+	}
 }
 {{< /tab >}}
 
@@ -379,18 +382,20 @@ while True:
         # The stream has closed
         break
 
-    # The transcript
-    print("text:", result.text)
-
-    # The confidence the ASR system has in the given transcript,
-    # given as a value between 0 and 1.0, with 1.0 being the most
-    # confident in the result. Note that partial results won't
-    # have an accurate confidence score.
-    print("confidence:", result.confidence)
-
     # Boolean indicating whether the result is partial (i.e., may
     # change with further processing).
-    print("partial:", result.is_partial)
+    if result.is_partial:
+        # Print the partial transcript.
+        print("partial transcript:", result.text)
+    else:
+        # Print the finalized transcript.
+        print("transcript:", result.text)
+
+        # The confidence the ASR system has in the given transcript,
+        # given as a value between 0 and 1.0, with 1.0 being the most
+        # confident in the result. Note that partial results won't
+        # have an accurate confidence score.
+        print("confidence:", result.confidence)
 {{< /tab >}}
 
 {{< tab "C++" "c++" >}}
@@ -401,18 +406,21 @@ while (true) {
         break;
     }
 
-    // The transcript
-    std::cout << "text: " << result.text() << std::endl;
-
-    // The confidence the ASR system has in the given transcript,
-    // given as a value between 0 and 1.0, with 1.0 being the most
-    // confident in the result. Note that partial results won't
-    // have an accurate confidence score.
-    std::cout << "confidence: " << result.confidence() << std::endl;
-
     // Boolean indicating whether the result is partial (i.e., may
     // change with further processing).
-    std::cout << "partial: " << result.is_partial() << std::endl;
+    if (result.is_partial()) {
+        // Print the partial transcript.
+        std::cout << "partial transcript: " << result.text() << std::endl;
+    } else {
+        // Print the finalized transcript.
+        std::cout << "transcript: " << result.text() << std::endl;
+
+        // The confidence the ASR system has in the given transcript,
+        // given as a value between 0 and 1.0, with 1.0 being the most
+        // confident in the result. Note that partial results won't
+        // have an accurate confidence score.
+        std::cout << "confidence: " << result.confidence() << std::endl;
+    }
 }
 {{< /tab >}}
 

--- a/docs-src/content/protobuf/_index.md
+++ b/docs-src/content/protobuf/_index.md
@@ -29,8 +29,9 @@ Service that implements the Cobalt Diatheke Dialog Management API.
 | CreateSession | [SessionStart](#SessionStart) | [SessionOutput](#SessionOutput) | Create a new Diatheke session. Also returns a list of actions to take next. |
 | DeleteSession | [TokenData](#TokenData) | [Empty](#Empty) | Delete the session. Behavior is undefined if the given TokenData is used again after this function is called. |
 | UpdateSession | [SessionInput](#SessionInput) | [SessionOutput](#SessionOutput) | Process input for a session and get an updated session with a list of actions to take next. This is the only method that modifies the Diatheke session state. |
-| StreamASR | [ASRInput](#ASRInput) | [ASRResult](#ASRResult) | Create an ASR stream. A result is returned when the stream is closed by the client (which forces the ASR to endpoint), or when a transcript becomes available on its own, in which case the stream is closed by the server. The ASR result may be used in the UpdateSession method. |
+| StreamASR | [ASRInput](#ASRInput) | [ASRResult](#ASRResult) | Create an ASR stream. A result is returned when the stream is closed by the client (which forces the ASR to endpoint), or when a transcript becomes available on its own, in which case the stream is closed by the server. The ASR result may be used in the UpdateSession method. <br/><br/> If the session has a wakeword enabled, and the client application is using Diatheke and Cubic to handle the wakeword processing, this method will not return a result until the wakeword condition has been satisfied. Utterances without the required wakeword will be discarded and no transcription will be returned. |
 | StreamTTS | [ReplyAction](#ReplyAction) | [TTSAudio](#TTSAudio) | Create a TTS stream to receive audio for the given reply. The stream will close when TTS is finished. The client may also close the stream early to cancel the speech synthesis. |
+| Transcribe | [TranscribeInput](#TranscribeInput) | [TranscribeResult](#TranscribeResult) | Create an ASR stream for transcription. Unlike StreamASR, Transcribe does not listen for a wakeword. This method returns a bi-directional stream, and its intended use is for situations where a user may say anything at all, whether it is short or long, and the application wants to save the transcript (e.g., take a note, send a message). <br/><br/> The first message sent to the server must include the Cubic model ID, with remaining messages sending audio data. Messages received from the server will include the current best partial transcription until the full transcription is ready. The stream ends when either the client application closes it, a predefined duration of silence (non-speech) occurs, or the end-transcription intent is recognized. |
 
  <!-- end services -->
 
@@ -81,6 +82,7 @@ Specifies an action that the client application should take.
 | input | [WaitForUserAction](#WaitForUserAction) |  | <p>The user must provide input to Diatheke.</p> |
 | command | [CommandAction](#CommandAction) |  | <p>The client app must execute the specified command.</p> |
 | reply | [ReplyAction](#ReplyAction) |  | <p>The client app should provide the reply to the user.</p> |
+| transcribe | [TranscribeAction](#TranscribeAction) |  | <p>The client app should transcribe user input.</p> |
 
 
 
@@ -261,6 +263,7 @@ Used to create a new session.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | model_id | [string](#string) |  | <p>Specifies the Diatheke model ID to use for the session.</p> |
+| wakeword | [string](#string) |  | <p>Specifies a custom wakeword to use for this session. The wakeword must be enabled in the Diatheke model for this to have any effect. It will override the default wakeword specified in the model.</p> |
 
 
 
@@ -343,6 +346,60 @@ current state.
 | data | [bytes](#bytes) |  | <p></p> |
 | id | [string](#string) |  | <p>Session ID, useful for correlating logging between a client and the server.</p> |
 | metadata | [string](#string) |  | <p>Additional data supplied by the client app, which will be logged with other session info by the server.</p> |
+
+
+
+
+
+
+
+<a name="TranscribeAction"></a>
+### Message: TranscribeAction
+This action indicates that the client application should
+transcribe the user's input.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) |  | <p>The ID of the transcribe action, which is useful to differentiate separate transcription tasks within a single sesssion.</p> |
+| cubic_model_id | [string](#string) |  | <p>The ASR model to use for transcription.</p> |
+| diatheke_model_id | [string](#string) |  | <p>The Diatheke model where this transcribe action is defined. If empty, the server will not be able to automatically close the transcribe stream based on conditions defined in the Diatheke model, such as a non-speech timeout or an "end-transcription" intent. When empty, the stream must be closed by the client application.</p> |
+
+
+
+
+
+
+
+<a name="TranscribeInput"></a>
+### Message: TranscribeInput
+Data to send to the Transcribe stream. The first message on
+the stream must be a TranscribeAction, followed by audio data.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| action | [TranscribeAction](#TranscribeAction) |  | <p>Action defining the transcribe configuration.</p> |
+| audio | [bytes](#bytes) |  | <p>Audio data to transcribe.</p> |
+
+
+
+
+
+
+
+<a name="TranscribeResult"></a>
+### Message: TranscribeResult
+The result from the Transcribe stream. Usually, many partial
+(or intermediate) transcriptions will be sent until the final
+transcription is ready for every utterance processed.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| text | [string](#string) |  | <p>The transcription.</p> |
+| confidence | [double](#double) |  | <p>Confidence estimate between 0 and 1. A higher number represents a higher likelihood of the transcription being correct.</p> |
+| is_partial | [bool](#bool) |  | <p>True if this is a partial result, in which case the text of the transcription for the current utterance being processed is allowed to change in future results. When false, this represents the final transcription for an utterance, which will not change with further audio input. It is sent when the ASR has endpointed. After the final transcription is sent, any additional results sent on the Transcribe stream belong to the next utterance.</p> |
 
 
 

--- a/docs-src/content/sessions/actions.md
+++ b/docs-src/content/sessions/actions.md
@@ -124,6 +124,9 @@ func processActions(sessionOutput: Cobaltspeech_Diatheke_SessionOutput) {
 		case .command(let commandAction):
 			// The CommandAction will involve a session update
 			self.handleCommand(commandAction)
+		case .transcribe(let transcribeAction):
+			// Transcribe actions do not require a session update.
+			self.handleTranscribe(transcribeAction)
 		}
 	}
 }
@@ -806,6 +809,29 @@ void handleTranscribe(Diatheke::Client *client,
      * results from the TranscribeStream, which is created using the
      * given transcribe action.
      */
+}
+{{< /tab >}}
+
+{{< tab "Swift/iOS" "swift" >}}
+/// Uses ASR to record a transcription from the user.
+func handleTranscribe(_ transcribeAction: Cobaltspeech_Diatheke_TranscribeAction) {
+	print("TranscribeAction:")
+
+	// The ID helps the application identify the purpose of this
+	// transcription (e.g., taking a note).
+	print("  ID: \(transcribeAction.id)")
+
+	// The Cubic model ID specifies which ASR model to use for
+	// transcription (defined by the server).
+	print("  Cubic Model ID: \(transcribeAction.cubicModelID)")
+
+	// The Diatheke model ID specifies which Diatheke model to use
+	// to check for stream-end conditions (e.g., timeout).
+	print("  Diatheke Model ID: \(transcribeAction.diathekeModelID)")
+
+	// The application should add code here to record audio and process
+	// results from the TranscribeStream, which is created using the
+	// given transcribe action.
 }
 {{< /tab >}}
 

--- a/grpc/diatheke.proto
+++ b/grpc/diatheke.proto
@@ -68,8 +68,8 @@ service Diatheke {
     // it is short or long, and the application wants to save the
     // transcript (e.g., take a note, send a message).
     // <br/><br/>
-    // The first message sent to the server must include the
-    // Cubic model ID, with remaining messages sending audio data.
+    // The first message sent to the server must be the TranscribeAction,
+    // with remaining messages sending audio data.
     // Messages received from the server will include the current
     // best partial transcription until the full transcription is
     // ready. The stream ends when either the client application
@@ -217,7 +217,8 @@ message ActionData {
         // The client app should provide the reply to the user.
         ReplyAction reply = 3;
 
-        // The client app should transcribe user input.
+        // The client app should call the Transcribe method to
+        // capture the user's input.
         TranscribeAction transcribe = 4;
     }
 }
@@ -255,20 +256,20 @@ message ReplyAction {
 }
 
 // This action indicates that the client application should
-// transcribe the user's input.
+// call the Transcribe method to capture the user's input.
 message TranscribeAction {
     // The ID of the transcribe action, which is useful to
     // differentiate separate transcription tasks within a
     // single sesssion.
     string id = 1;
 
-    // The ASR model to use for transcription.
+    // (Required) The ASR model to use for transcription.
     string cubic_model_id = 2;
 
-    // The Diatheke model where this transcribe action is
-    // defined. If empty, the server will not be able to
+    // (Optional) A Diatheke model to use for end-of-stream
+    // conditions. If empty, the server will not be able to
     // automatically close the transcribe stream based on
-    // conditions defined in the Diatheke model, such as
+    // conditions defined in the model, such as
     // a non-speech timeout or an "end-transcription" intent.
     // When empty, the stream must be closed by the client
     // application.
@@ -328,7 +329,7 @@ message TranscribeInput {
     }
 }
 
-// The result from the Transcribe stream. Usually, many partial
+// The result from the Transcribe stream. Usually, several partial
 // (or intermediate) transcriptions will be sent until the final
 // transcription is ready for every utterance processed.
 message TranscribeResult {
@@ -336,18 +337,18 @@ message TranscribeResult {
     string text = 1;
 
     // Confidence estimate between 0 and 1. A higher number
-    // represents a higher likelihood of the transcription
-    // being correct.
+    // represents a higher likelihood that the transcription
+    // is correct.
     double confidence = 2;
 
     // True if this is a partial result, in which case the
-    // text of the transcription for the current utterance
-    // being processed is allowed to change in future results.
-    // When false, this represents the final transcription for
-    // an utterance, which will not change with further audio
-    // input. It is sent when the ASR has endpointed. After the
-    // final transcription is sent, any additional results sent
-    // on the Transcribe stream belong to the next utterance.
+    // next result will be for the same audio, either repeating
+    // or correcting the text in this result. When false, this
+    // represents the final transcription for an utterance, which
+    // will not change with further audio input. It is sent when
+    // the ASR has identified an endpoint. After the final
+    // transcription is sent, any additional results sent on the
+    // Transcribe stream belong to the next utterance.
     bool is_partial = 3;
 }
 

--- a/grpc/diatheke.proto
+++ b/grpc/diatheke.proto
@@ -46,7 +46,7 @@ service Diatheke {
     // endpoint), or when a transcript becomes available on its
     // own, in which case the stream is closed by the server.
     // The ASR result may be used in the UpdateSession method.
-    //
+    // <br/><br/>
     // If the session has a wakeword enabled, and the client
     // application is using Diatheke and Cubic to handle the
     // wakeword processing, this method will not return a
@@ -67,7 +67,7 @@ service Diatheke {
     // for situations where a user may say anything at all, whether
     // it is short or long, and the application wants to save the
     // transcript (e.g., take a note, send a message).
-    //
+    // <br/><br/>
     // The first message sent to the server must include the
     // Cubic model ID, with remaining messages sending audio data.
     // Messages received from the server will include the current

--- a/grpc/swift-diatheke/TranscribeStream.swift
+++ b/grpc/swift-diatheke/TranscribeStream.swift
@@ -71,11 +71,11 @@ public class TranscribeStream {
         return result
     }
     
-    // result waits for the next transcribe result from
+    // finish waits for the next transcribe result from
     // Diatheke. When the returned error is io.EOF, the stream has
     // been closed and no more results will be sent from Diatheke.
     @discardableResult
-    public func result(completion: ((Error?) -> ())?) -> EventLoopFuture<Void> {
+    public func finish(completion: ((Error?) -> ())?) -> EventLoopFuture<Void> {
         let result = stream.sendEnd()
         result.whenComplete { (result) in
             switch result {

--- a/grpc/swift-diatheke/diatheke.grpc.swift
+++ b/grpc/swift-diatheke/diatheke.grpc.swift
@@ -178,7 +178,7 @@ extension Cobaltspeech_Diatheke_DiathekeClientProtocol {
   /// endpoint), or when a transcript becomes available on its
   /// own, in which case the stream is closed by the server.
   /// The ASR result may be used in the UpdateSession method.
-  ///
+  /// <br/><br/>
   /// If the session has a wakeword enabled, and the client
   /// application is using Diatheke and Cubic to handle the
   /// wakeword processing, this method will not return a
@@ -232,9 +232,9 @@ extension Cobaltspeech_Diatheke_DiathekeClientProtocol {
   /// for situations where a user may say anything at all, whether
   /// it is short or long, and the application wants to save the
   /// transcript (e.g., take a note, send a message).
-  ///
-  /// The first message sent to the server must include the
-  /// Cubic model ID, with remaining messages sending audio data.
+  /// <br/><br/>
+  /// The first message sent to the server must be the TranscribeAction,
+  /// with remaining messages sending audio data.
   /// Messages received from the server will include the current
   /// best partial transcription until the full transcription is
   /// ready. The stream ends when either the client application

--- a/grpc/swift-diatheke/diatheke.pb.swift
+++ b/grpc/swift-diatheke/diatheke.pb.swift
@@ -356,7 +356,8 @@ public struct Cobaltspeech_Diatheke_ActionData {
     set {action = .reply(newValue)}
   }
 
-  /// The client app should transcribe user input.
+  /// The client app should call the Transcribe method to
+  /// capture the user's input.
   public var transcribe: Cobaltspeech_Diatheke_TranscribeAction {
     get {
       if case .transcribe(let v)? = action {return v}
@@ -374,7 +375,8 @@ public struct Cobaltspeech_Diatheke_ActionData {
     case command(Cobaltspeech_Diatheke_CommandAction)
     /// The client app should provide the reply to the user.
     case reply(Cobaltspeech_Diatheke_ReplyAction)
-    /// The client app should transcribe user input.
+    /// The client app should call the Transcribe method to
+    /// capture the user's input.
     case transcribe(Cobaltspeech_Diatheke_TranscribeAction)
 
   #if !swift(>=4.1)
@@ -466,7 +468,7 @@ public struct Cobaltspeech_Diatheke_ReplyAction {
 }
 
 /// This action indicates that the client application should
-/// transcribe the user's input.
+/// call the Transcribe method to capture the user's input.
 public struct Cobaltspeech_Diatheke_TranscribeAction {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -477,13 +479,13 @@ public struct Cobaltspeech_Diatheke_TranscribeAction {
   /// single sesssion.
   public var id: String = String()
 
-  /// The ASR model to use for transcription.
+  /// (Required) The ASR model to use for transcription.
   public var cubicModelID: String = String()
 
-  /// The Diatheke model where this transcribe action is
-  /// defined. If empty, the server will not be able to
+  /// (Optional) A Diatheke model to use for end-of-stream
+  /// conditions. If empty, the server will not be able to
   /// automatically close the transcribe stream based on
-  /// conditions defined in the Diatheke model, such as
+  /// conditions defined in the model, such as
   /// a non-speech timeout or an "end-transcription" intent.
   /// When empty, the stream must be closed by the client
   /// application.
@@ -657,7 +659,7 @@ public struct Cobaltspeech_Diatheke_TranscribeInput {
   public init() {}
 }
 
-/// The result from the Transcribe stream. Usually, many partial
+/// The result from the Transcribe stream. Usually, several partial
 /// (or intermediate) transcriptions will be sent until the final
 /// transcription is ready for every utterance processed.
 public struct Cobaltspeech_Diatheke_TranscribeResult {
@@ -669,18 +671,18 @@ public struct Cobaltspeech_Diatheke_TranscribeResult {
   public var text: String = String()
 
   /// Confidence estimate between 0 and 1. A higher number
-  /// represents a higher likelihood of the transcription
-  /// being correct.
+  /// represents a higher likelihood that the transcription
+  /// is correct.
   public var confidence: Double = 0
 
   /// True if this is a partial result, in which case the
-  /// text of the transcription for the current utterance
-  /// being processed is allowed to change in future results.
-  /// When false, this represents the final transcription for
-  /// an utterance, which will not change with further audio
-  /// input. It is sent when the ASR has endpointed. After the
-  /// final transcription is sent, any additional results sent
-  /// on the Transcribe stream belong to the next utterance.
+  /// next result will be for the same audio, either repeating
+  /// or correcting the text in this result. When false, this
+  /// represents the final transcription for an utterance, which
+  /// will not change with further audio input. It is sent when
+  /// the ASR has identified an endpoint. After the final
+  /// transcription is sent, any additional results sent on the
+  /// Transcribe stream belong to the next utterance.
   public var isPartial: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()


### PR DESCRIPTION
Added descriptions for the new Transcribe method and supporting
Transcribe action. Included examples for Go, Python, and C++.
Also updated the Python StreamASR convenience function example to
use the updated client based method.

Regenerated the protobuf API docs to reflect the latest protobuf
file, and fixed a typo in the protobuf comments that was manifest
in the autogenerated file.