### PR TITLE
chore: Update version strings to prepare for next release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ A few system dependencies are required:
 
 The top level Makefile can set up all other dependencies.
 
-Documentation is authored in the `docs-src` folder and generated static website
-is stored in the `docs` folder.
+Documentation is authored in the `docs-src` folder. Final documentation
+website is auto-generated and hosted by Cobalt, so there is no need to
+commit generated docs.
 
 To generate the code and documentation, run `make`.  This is currently only
 supported under linux.
@@ -54,16 +55,12 @@ cd docs-src
 ### Tagging New Versions
 
 This repository has several components, and they need more than just a "vX.Y.Z"
-tag on the git repo.  In particular, this repository has two go modules, one of
-which depends on the other, and in order to make sure correct versions are used,
-we need to follow a few careful steps to release new versions on this
-repository.
+tag on the git repo. We need to follow a few careful steps to release new versions:
 
-Step 1: Make sure all generated code and documentation is up to date.
+Step 1: Make sure all generated code is up to date.
 
 ```
 pushd grpc && make && popd
-pushd docs-src && hugo -d ../docs && popd
 git diff --quiet || echo "You have uncommitted changes.  Please get them merged in via a PR before updating versions."
 ```
 
@@ -85,8 +82,7 @@ git checkout master
 git checkout -b version-update-v$NEW_VERSION
 
 sed -i 's|DiathekeSDKVersion = "[0-9.]*"|DiathekeSDKVersion = "'$NEW_VERSION'"|g' grpc/swift-diatheke/Diatheke.swift
-sed -i 's|.upToNextMajor(from: "[0-9.]*")|.upToNextMajor(from: "'$NEW_VERSION'")|g' docs-src/content/using-diatheke-sdk/include.md
-pushd docs-src && hugo -d ../docs && popd
+sed -i 's|.upToNextMajor(from: "[0-9.]*")|.upToNextMajor(from: "'$NEW_VERSION'")|g' docs-src/content/including-sdk/_index.md
 
 git commit -m "Update version to v$NEW_VERSION"
 git push origin version-update-v$NEW_VERSION

--- a/docs-src/content/including-sdk/_index.md
+++ b/docs-src/content/including-sdk/_index.md
@@ -43,7 +43,7 @@ from GitHub to use in your Go project.
 ## Python
 The Python SDK requires Python v3.5.0 or greater. The SDK may be installed
 from GitHub using `pip` as shown below, where `<VERSION>` is the specific
-version of the SDK the application is targeting (e.g., `v1.3.0`, `v2.0.0`, etc.)
+version of the SDK the application is targeting (e.g., `v1.3.0`, `v2.1.0`, etc.)
 
 ```bash
 # Replace <VERSION> with the desired SDK version
@@ -55,9 +55,9 @@ To get `v1.3.0`
 pip install "git+https://github.com/cobaltspeech/sdk-diatheke@v1.3.0#egg=cobalt-diatheke&subdirectory=grpc/py-diatheke"
 ```
 
-To get `v2.0.0`
+To get `v2.1.0`
 ```bash
-pip install "git+https://github.com/cobaltspeech/sdk-diatheke@v2.0.0#egg=cobalt-diatheke&subdirectory=grpc/py-diatheke"
+pip install "git+https://github.com/cobaltspeech/sdk-diatheke@v2.1.0#egg=cobalt-diatheke&subdirectory=grpc/py-diatheke"
 ```
 
 To get the latest master (not recommended for production)
@@ -85,7 +85,7 @@ dependency is as easy as adding it to the `dependencies` value of your
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/cobaltspeech/sdk-diatheke.git", .upToNextMajor(from: "2.0"))
+    .package(url: "https://github.com/cobaltspeech/sdk-diatheke.git", .upToNextMajor(from: "2.1.0"))
 ]
 ```
 

--- a/grpc/cpp-diatheke/README.md
+++ b/grpc/cpp-diatheke/README.md
@@ -49,7 +49,7 @@ include(FetchContent)
 FetchContent_Declare(
     sdk_diatheke
     GIT_REPOSITORY https://github.com/cobaltspeech/sdk-diatheke.git
-    GIT_TAG v2.0.1
+    GIT_TAG v2.1.0
 )
 FetchContent_Populate(sdk_diatheke)
 

--- a/grpc/go-diatheke/v2/diathekepb/diatheke.pb.go
+++ b/grpc/go-diatheke/v2/diathekepb/diatheke.pb.go
@@ -844,7 +844,8 @@ type ActionData_Reply struct {
 }
 
 type ActionData_Transcribe struct {
-	// The client app should transcribe user input.
+	// The client app should call the Transcribe method to
+	// capture the user's input.
 	Transcribe *TranscribeAction `protobuf:"bytes,4,opt,name=transcribe,proto3,oneof"`
 }
 
@@ -1037,7 +1038,7 @@ func (x *ReplyAction) GetLunaModel() string {
 }
 
 // This action indicates that the client application should
-// transcribe the user's input.
+// call the Transcribe method to capture the user's input.
 type TranscribeAction struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1047,12 +1048,12 @@ type TranscribeAction struct {
 	// differentiate separate transcription tasks within a
 	// single sesssion.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// The ASR model to use for transcription.
+	// (Required) The ASR model to use for transcription.
 	CubicModelId string `protobuf:"bytes,2,opt,name=cubic_model_id,json=cubicModelId,proto3" json:"cubic_model_id,omitempty"`
-	// The Diatheke model where this transcribe action is
-	// defined. If empty, the server will not be able to
+	// (Optional) A Diatheke model to use for end-of-stream
+	// conditions. If empty, the server will not be able to
 	// automatically close the transcribe stream based on
-	// conditions defined in the Diatheke model, such as
+	// conditions defined in the model, such as
 	// a non-speech timeout or an "end-transcription" intent.
 	// When empty, the stream must be closed by the client
 	// application.
@@ -1407,7 +1408,7 @@ func (*TranscribeInput_Action) isTranscribeInput_Data() {}
 
 func (*TranscribeInput_Audio) isTranscribeInput_Data() {}
 
-// The result from the Transcribe stream. Usually, many partial
+// The result from the Transcribe stream. Usually, several partial
 // (or intermediate) transcriptions will be sent until the final
 // transcription is ready for every utterance processed.
 type TranscribeResult struct {
@@ -1418,17 +1419,17 @@ type TranscribeResult struct {
 	// The transcription.
 	Text string `protobuf:"bytes,1,opt,name=text,proto3" json:"text,omitempty"`
 	// Confidence estimate between 0 and 1. A higher number
-	// represents a higher likelihood of the transcription
-	// being correct.
+	// represents a higher likelihood that the transcription
+	// is correct.
 	Confidence float64 `protobuf:"fixed64,2,opt,name=confidence,proto3" json:"confidence,omitempty"`
 	// True if this is a partial result, in which case the
-	// text of the transcription for the current utterance
-	// being processed is allowed to change in future results.
-	// When false, this represents the final transcription for
-	// an utterance, which will not change with further audio
-	// input. It is sent when the ASR has endpointed. After the
-	// final transcription is sent, any additional results sent
-	// on the Transcribe stream belong to the next utterance.
+	// next result will be for the same audio, either repeating
+	// or correcting the text in this result. When false, this
+	// represents the final transcription for an utterance, which
+	// will not change with further audio input. It is sent when
+	// the ASR has identified an endpoint. After the final
+	// transcription is sent, any additional results sent on the
+	// Transcribe stream belong to the next utterance.
 	IsPartial bool `protobuf:"varint,3,opt,name=is_partial,json=isPartial,proto3" json:"is_partial,omitempty"`
 }
 
@@ -2154,7 +2155,7 @@ type DiathekeClient interface {
 	// endpoint), or when a transcript becomes available on its
 	// own, in which case the stream is closed by the server.
 	// The ASR result may be used in the UpdateSession method.
-	//
+	// <br/><br/>
 	// If the session has a wakeword enabled, and the client
 	// application is using Diatheke and Cubic to handle the
 	// wakeword processing, this method will not return a
@@ -2173,9 +2174,9 @@ type DiathekeClient interface {
 	// for situations where a user may say anything at all, whether
 	// it is short or long, and the application wants to save the
 	// transcript (e.g., take a note, send a message).
-	//
-	// The first message sent to the server must include the
-	// Cubic model ID, with remaining messages sending audio data.
+	// <br/><br/>
+	// The first message sent to the server must be the TranscribeAction,
+	// with remaining messages sending audio data.
 	// Messages received from the server will include the current
 	// best partial transcription until the full transcription is
 	// ready. The stream ends when either the client application
@@ -2356,7 +2357,7 @@ type DiathekeServer interface {
 	// endpoint), or when a transcript becomes available on its
 	// own, in which case the stream is closed by the server.
 	// The ASR result may be used in the UpdateSession method.
-	//
+	// <br/><br/>
 	// If the session has a wakeword enabled, and the client
 	// application is using Diatheke and Cubic to handle the
 	// wakeword processing, this method will not return a
@@ -2375,9 +2376,9 @@ type DiathekeServer interface {
 	// for situations where a user may say anything at all, whether
 	// it is short or long, and the application wants to save the
 	// transcript (e.g., take a note, send a message).
-	//
-	// The first message sent to the server must include the
-	// Cubic model ID, with remaining messages sending audio data.
+	// <br/><br/>
+	// The first message sent to the server must be the TranscribeAction,
+	// with remaining messages sending audio data.
 	// Messages received from the server will include the current
 	// best partial transcription until the full transcription is
 	// ready. The stream ends when either the client application

--- a/grpc/py-diatheke/diatheke/diatheke_pb2_grpc.py
+++ b/grpc/py-diatheke/diatheke/diatheke_pb2_grpc.py
@@ -106,7 +106,7 @@ class DiathekeServicer(object):
         endpoint), or when a transcript becomes available on its
         own, in which case the stream is closed by the server.
         The ASR result may be used in the UpdateSession method.
-
+        <br/><br/>
         If the session has a wakeword enabled, and the client
         application is using Diatheke and Cubic to handle the
         wakeword processing, this method will not return a
@@ -135,9 +135,9 @@ class DiathekeServicer(object):
         for situations where a user may say anything at all, whether
         it is short or long, and the application wants to save the
         transcript (e.g., take a note, send a message).
-
-        The first message sent to the server must include the
-        Cubic model ID, with remaining messages sending audio data.
+        <br/><br/>
+        The first message sent to the server must be the TranscribeAction,
+        with remaining messages sending audio data.
         Messages received from the server will include the current
         best partial transcription until the full transcription is
         ready. The stream ends when either the client application

--- a/grpc/swift-diatheke/Diatheke.swift
+++ b/grpc/swift-diatheke/Diatheke.swift
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public let DiathekeSDKVersion = "2.0"
+public let DiathekeSDKVersion = "2.1.0"


### PR DESCRIPTION
Updated strings where necessary in documentation (and a little swift
code) with the version string for the v2.1.0 release of the SDK.

Updated the main README file instructions for tagging a release
to reflect that we no longer commit generated documentation files.

Re-generated go and python grpc code to reflect latest changes to
the protobuf file. All these changes are related to comments, and
should not change any code or behaviors.