### PR TITLE
#1upx91t fix (cpp): Modify ASRStream implementation to better respond to results.

### DIFF
--- a/grpc/cpp-diatheke/CMakeLists.txt
+++ b/grpc/cpp-diatheke/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (2021) Cobalt Speech and Language, Inc.
+# Copyright (2021-present) Cobalt Speech and Language, Inc. All rights reserved.
 
 cmake_minimum_required(VERSION 3.14.0)
 project(diatheke_client)

--- a/grpc/cpp-diatheke/diatheke_asr_stream.cpp
+++ b/grpc/cpp-diatheke/diatheke_asr_stream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (2021) Cobalt Speech and Language, Inc.
+ * Copyright (2021-present) Cobalt Speech and Language, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,14 +18,65 @@
 
 #include "diatheke_client_error.h"
 
+#include <atomic>
+#include <thread>
+
 namespace Diatheke
 {
-ASRStream::ASRStream(
-    const std::shared_ptr<grpc::ClientContext> &ctx,
-    const std::shared_ptr<cobaltspeech::diatheke::ASRResult> &result,
-    const std::shared_ptr<GRPCWriter> &stream)
-    : mContext(ctx), mResult(result), mStream(stream)
+
+/* Private data struct */
+struct ASRStreamPrivate
 {
+    grpc::ClientContext context;
+    cobaltspeech::diatheke::ASRResult result;
+    std::shared_ptr<ASRStream::GRPCWriter> stream;
+    std::atomic_bool hasResult;
+    std::thread resultThread;
+    grpc::Status status;
+
+    ~ASRStreamPrivate()
+    {
+        if (!hasResult.load()) {
+            // This indicates that the stream hasn't returned
+            // yet, so we need to force it to close by
+            // cancelling the stream's context.
+            context.TryCancel();
+        }
+        
+        // Make sure the thread has joined
+        join();
+    }
+
+    void startResultThread()
+    {
+        // Wait for results on a separate thread.
+        mJoined = false;
+        resultThread = std::thread([](ASRStreamPrivate *data){
+            data->status = data->stream->Finish();
+            data->hasResult = true;
+        }, this);
+    }
+
+    void join()
+    {
+        if (mJoined) {
+            return;
+        }
+
+        mJoined = true;
+        resultThread.join();
+    }
+
+private:
+    bool mJoined;
+};
+
+ASRStream::ASRStream(cobaltspeech::diatheke::Diatheke::Stub *stub)
+    : dPtr(std::make_shared<ASRStreamPrivate>())
+{
+    dPtr->stream = stub->StreamASR(&dPtr->context, &dPtr->result);
+    dPtr->hasResult = false;
+    dPtr->startResultThread();
 }
 
 ASRStream::~ASRStream() {}
@@ -35,7 +86,11 @@ bool ASRStream::sendAudio(const std::string &data)
     // Set up the request and write to the input stream
     cobaltspeech::diatheke::ASRInput request;
     request.set_audio(data);
-    return mStream->Write(request);
+    if (!dPtr->stream->Write(request)) {
+        return false;
+    }
+
+    return !dPtr->hasResult.load();
 }
 
 bool ASRStream::sendToken(const cobaltspeech::diatheke::TokenData &token)
@@ -43,21 +98,33 @@ bool ASRStream::sendToken(const cobaltspeech::diatheke::TokenData &token)
     // Set up the request and write to the input stream
     cobaltspeech::diatheke::ASRInput request;
     *(request.mutable_token()) = token;
-    return mStream->Write(request);
+    if (!dPtr->stream->Write(request)) {
+        return false;
+    }
+
+    return !dPtr->hasResult.load();
 }
 
 cobaltspeech::diatheke::ASRResult ASRStream::result()
 {
-    mStream->WritesDone();
-    grpc::Status status = mStream->Finish();
-    if (!status.ok())
-    {
-        throw Diatheke::ClientError(status);
+    // If Diatheke hasn't already sent the result,
+    // notify it that no more writes are coming, which
+    // should force a result.
+    if (!dPtr->hasResult.load()) {
+        dPtr->stream->WritesDone();
     }
 
-    return *mResult;
+    // Wait for the result to come back.
+    dPtr->join();
+
+    // Check the status and return the result.
+    if (!dPtr->status.ok()) {
+        throw Diatheke::ClientError(dPtr->status);
+    }
+
+    return dPtr->result;
 }
 
-ASRStream::GRPCWriter *ASRStream::getStream() { return mStream.get(); }
+ASRStream::GRPCWriter *ASRStream::getStream() { return dPtr->stream.get(); }
 
 } // namespace Diatheke

--- a/grpc/cpp-diatheke/diatheke_asr_stream.h
+++ b/grpc/cpp-diatheke/diatheke_asr_stream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (2021) Cobalt Speech and Language, Inc.
+ * Copyright (2021-present) Cobalt Speech and Language, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@
 namespace Diatheke
 {
 
+class ASRStreamPrivate;
+
 class ASRStream
 {
 public:
@@ -35,9 +37,7 @@ public:
      * Most callers should use Client::newSessionASRStream() instead
      * of creating a new stream directly.
      */
-    ASRStream(const std::shared_ptr<grpc::ClientContext> &ctx,
-              const std::shared_ptr<cobaltspeech::diatheke::ASRResult> &result,
-              const std::shared_ptr<GRPCWriter> &stream);
+    ASRStream(cobaltspeech::diatheke::Diatheke::Stub *stub);
     ~ASRStream();
 
     /*
@@ -80,9 +80,7 @@ public:
     GRPCWriter *getStream();
 
 private:
-    std::shared_ptr<grpc::ClientContext> mContext;
-    std::shared_ptr<cobaltspeech::diatheke::ASRResult> mResult;
-    std::shared_ptr<GRPCWriter> mStream;
+    std::shared_ptr<ASRStreamPrivate> dPtr; // Opaque pointer
 };
 
 } // namespace Diatheke

--- a/grpc/cpp-diatheke/diatheke_client.cpp
+++ b/grpc/cpp-diatheke/diatheke_client.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (2021) Cobalt Speech and Language, Inc.
+ * Copyright (2021-present) Cobalt Speech and Language, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -220,25 +220,8 @@ Client::setStory(const cobaltspeech::diatheke::TokenData &token,
 ASRStream
 Client::newSessionASRStream(const cobaltspeech::diatheke::TokenData &token)
 {
-    /*
-     * Create the context. We need it to exist for the lifetime of the
-     * stream, so we create it as a managed pointer. We don't set a
-     * deadline on the context because we expect the stream to be long-
-     * lived.
-     */
-    std::shared_ptr<grpc::ClientContext> ctx(new grpc::ClientContext);
-
-    // Create a managed pointer to store the final result.
-    std::shared_ptr<cobaltspeech::diatheke::ASRResult> result(
-        new cobaltspeech::diatheke::ASRResult);
-
-    // Create the gRPC stream
-    std::shared_ptr<ASRStream::GRPCWriter> writer(
-        mStub->StreamASR(ctx.get(), result.get()));
-
-    // Store the pointers in our ASRStream object, then send the session
-    // token.
-    ASRStream stream(ctx, result, writer);
+     // Create the ASR stream object.
+    ASRStream stream(mStub.get());
     if (!stream.sendToken(token))
     {
         throw ClientError(

--- a/grpc/cpp-diatheke/diatheke_client.h
+++ b/grpc/cpp-diatheke/diatheke_client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (2021) Cobalt Speech and Language, Inc.
+ * Copyright (2021-present) Cobalt Speech and Language, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
It turns out that the bool returned by the underlying gRPC stream
Write() method, didn't quite mean what I thought it meant (C++ API
docs aren't very clear on this point). The Write() method will
return false when the stream is closed, but not necessarily when
the result is available. However, the result IS available as soon
as the stream's Finish() method returns. Experiments confirm that
this function can return a good 400-500ms before the Write() method
returns false. So, to improve the notification of when a result is
available, the ASRStream implementation was updated to listen for
a result (via the blocking Finish method) on a separate thread.
Using an atomic bool as a flag, we then let the calling thread know
when a result is available by returning false from the ASRStream's
send methods once the flag is set. This greatly improves the time
it takes for a client to get the ASR result.

Also simplified the creation of the ASRStream by passing in the
client Stub pointer, and better organized the class by storing
internal class data in an opaque pointer (also helps with issues
related to storing a std::thread object in a class).